### PR TITLE
introduce excludeITModules property

### DIFF
--- a/kogito-codegen-modules/pom.xml
+++ b/kogito-codegen-modules/pom.xml
@@ -35,6 +35,16 @@
       </activation>
       <modules>
         <module>kogito-codegen-sample</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>integration-test-modules</id>
+      <activation>
+        <property>
+          <name>!excludeITModules</name>
+        </property>
+      </activation>
+      <modules>
         <module>kogito-codegen-integration-tests</module>
       </modules>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,16 @@
       <modules>
         <module>kogito-test-utils</module>
         <module>kogito-cloud-services</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>integration-test-modules</id>
+      <activation>
+        <property>
+          <name>!excludeITModules</name>
+        </property>
+      </activation>
+      <modules>
         <module>integration-tests</module>
       </modules>
     </profile>

--- a/quarkus/extensions/kogito-quarkus-decisions-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-decisions-extension/pom.xml
@@ -20,10 +20,10 @@
 
   <profiles>
     <profile>
-      <id>default</id>
+      <id>integration-test-modules</id>
       <activation>
         <property>
-          <name>!productized</name>
+          <name>!excludeITModules</name>
         </property>
       </activation>
       <modules>

--- a/quarkus/extensions/kogito-quarkus-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-extension/pom.xml
@@ -21,10 +21,10 @@
 
   <profiles>
     <profile>
-      <id>default</id>
+      <id>integration-test-modules</id>
       <activation>
         <property>
-          <name>!productized</name>
+          <name>!excludeITModules</name>
         </property>
       </activation>
       <modules>

--- a/quarkus/extensions/kogito-quarkus-predictions-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-predictions-extension/pom.xml
@@ -20,10 +20,10 @@
 
   <profiles>
     <profile>
-      <id>default</id>
+      <id>integration-test-modules</id>
       <activation>
         <property>
-          <name>!productized</name>
+          <name>!excludeITModules</name>
         </property>
       </activation>
       <modules>

--- a/quarkus/extensions/kogito-quarkus-processes-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-processes-extension/pom.xml
@@ -20,10 +20,10 @@
 
   <profiles>
     <profile>
-      <id>default</id>
+      <id>integration-test-modules</id>
       <activation>
         <property>
-          <name>!productized</name>
+          <name>!excludeITModules</name>
         </property>
       </activation>
       <modules>

--- a/quarkus/extensions/kogito-quarkus-rules-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-rules-extension/pom.xml
@@ -20,10 +20,10 @@
 
   <profiles>
     <profile>
-      <id>default</id>
+      <id>integration-test-modules</id>
       <activation>
         <property>
-          <name>!productized</name>
+          <name>!excludeITModules</name>
         </property>
       </activation>
       <modules>

--- a/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/pom.xml
+++ b/quarkus/extensions/kogito-quarkus-serverless-workflow-extension/pom.xml
@@ -17,6 +17,19 @@
   <modules>
     <module>kogito-quarkus-serverless-workflow</module>
     <module>kogito-quarkus-serverless-workflow-deployment</module>
-    <module>kogito-quarkus-serverless-workflow-integration-test</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <id>integration-test-modules</id>
+      <activation>
+        <property>
+          <name>!excludeITModules</name>
+        </property>
+      </activation>
+      <modules>
+        <module>kogito-quarkus-serverless-workflow-integration-test</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Introduce a new property to exclude IT test modules instead of `productized` to provide more configuration options.